### PR TITLE
Only add `quantity` or `units` keys in step directions if they are defined

### DIFF
--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -151,20 +151,23 @@ export class Parser {
 
                 // single word ingredient
                 if (groups.sIngredientName) {
+                    const quantity = this.defaultIngredientAmount
                     step.push({
                         type: 'ingredient',
                         name: groups.sIngredientName,
-                        quantity: this.defaultIngredientAmount,
+                        ...(quantity ? { quantity } : {}),
                     })
                 }
 
                 // multiword ingredient
                 if (groups.mIngredientName) {
+                    const quantity = parseQuantity(groups.mIngredientQuantity, this.defaultIngredientAmount)
+                    const units = parseUnits(groups.mIngredientUnits)
                     step.push({
                         type: 'ingredient',
                         name: groups.mIngredientName,
-                        quantity: parseQuantity(groups.mIngredientQuantity, this.defaultIngredientAmount),
-                        units: parseUnits(groups.mIngredientUnits),
+                        ...(quantity ? { quantity } : {}),
+                        ...(units ? { units } : {}),
                     })
                 }
 
@@ -178,20 +181,23 @@ export class Parser {
 
                 // multiword cookware
                 if (groups.mCookwareName) {
+                    const quantity = parseQuantity(groups.mCookwareQuantity)
                     step.push({
                         type: 'cookware',
                         name: groups.mCookwareName,
-                        quantity: parseQuantity(groups.mCookwareQuantity),
+                        ...(quantity ? { quantity } : {}),
                     })
                 }
 
                 // timer
                 if (groups.timerQuantity) {
+                    const quantity = parseQuantity(groups.timerQuantity)
+                    const units = parseUnits(groups.timerUnits)
                     step.push({
                         type: 'timer',
                         name: groups.timerName,
-                        quantity: parseQuantity(groups.timerQuantity),
-                        units: parseUnits(groups.timerUnits),
+                        ...(quantity ? { quantity } : {}),
+                        ...(units ? { units } : {}),
                     })
                 }
 
@@ -245,11 +251,13 @@ function parseShoppingListItems(items: string): Array<ShoppingListItem> {
 
         if (item == '') continue;
 
-        const [name, synonym] = item.split('|');
+        const [namePart, synonymPart] = item.split('|');
+        const name = namePart.trim();
+        const synonym = synonymPart?.trim();
 
         list.push({
-            name: name.trim(),
-            synonym: synonym?.trim() || '',
+            name,
+            ...(synonym ? { synonym } : {}),
         })
     }
 


### PR DESCRIPTION
Prior to this change, if a quantity or a unit is undefined for an ingredient, cookware, or timer, then the resulting parsed direction item would still include the `quantity` or `unit` key despite the value being undefined.

For example, given the following ingredient:

```
@cauliflower{1}
```

The resulting parsed direction item would be:

```js
{
  "type": "ingredient",
  "name": "cauliflower",
  "quantity": 1,
  "units": undefined
}
```

The problem with this is that it makes it trickier to convert the resulting steps structure to JSON using `JSON.stringify()`, as undefined is not a native JSON value:

```
Reason: `undefined` cannot be serialized as JSON. Please use `null` or omit this value.
```

This commit causes the keys to be omitted from the structure entirely if their values are undefined:

```js
{
  "type": "ingredient",
  "name": "cauliflower",
  "quantity": 1
}
```

The `quantity` and `units` keys in the `StepIngredient`, `StepCookware` and `StepTimer` types are already marked as optional, so omitting the keys entirely should not cause any issues.