### PR TITLE
Fix greedy block comments

### DIFF
--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -9,7 +9,7 @@ const singleWordCookware = /#(?<sCookwareName>[^\s]+)/;
 const timer = /~(?<timerName>.*?)(?:{(?<timerQuantity>.*?)(?:%(?<timerUnits>.+))?})/;
 
 export const comment = /--.*/g;
-export const blockComment = /\s*\[-[^]*-\]\s*/g;
+export const blockComment = /\s*\[\-.*?\-\]\s*/g;
 
 export const shoppingListToken = /\[(?<name>.+)\](?<items>[^]*?)(?:\n\n|$)/g;
 export const tokens = new RegExp([metadata, multiwordIngredient, singleWordIngredient, multiwordCookware, singleWordCookware, timer].map(r => r.source).join('|'), 'g');

--- a/tests/custom.yaml
+++ b/tests/custom.yaml
@@ -20,6 +20,26 @@ tests:
             name: ""
       metadata: []
 
+  testMultipleBlockComments:
+    source: |
+      Add some [- comment -] @salt and [- another comment -] @pepper
+    result:
+      steps:
+        -
+          - type: text
+            value: "Add some "
+          - type: ingredient
+            quantity: "some"
+            units: ""
+            name: "salt"
+          - type: text
+            value: " and "
+          - type: ingredient
+            quantity: "some"
+            units: ""
+            name: "pepper"
+      metadata: []
+
   testMultiWordFollowingSingleWordIngredient:
     source: |
       @ingredient and @ingredient with spaces{}


### PR DESCRIPTION
This is a fix for #3. It adds a couple of tweaks to the block comment regex:

* Adds more escaping to make matching of `[-` and `-]` a bit clearer.
* Replaces `[^]*` wildcard match for characters inside comment with `.*?`, which is a non-greedy wildcard - i.e. it will match any characters unless those characters match the follow `-]` literal.

I've also added a test to demonstrate the bug and the fix, as well as to ensure the bug isn't introduced again in the future.

As I noted in #3, tweaking the regex like this is really only a short-sighted fix. As the cooklang language evolves, I expect these regexes will get harder to maintain and more bugs like this one will crop up. In addition, the non-greedy wildcard matching means the node regex engine will have to do more backtracking when matching the regex - which will likely start to impact performance if introduced in more places.