### PR TITLE
Fixed parsing behavior for non-numeric quantities that contain a slash

### DIFF
--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -182,6 +182,8 @@ function parseQuantity(quantity?: string): string | number | undefined {
 
     const [numLeft, numRight] = [Number(left), Number(right)];
 
+    if(right && isNaN(numRight)) return quantity;
+
     if (!isNaN(numLeft) && !numRight) return numLeft;
     else if (!isNaN(numLeft) && !isNaN(numRight) && !(left.startsWith('0') || right.startsWith('0'))) return numLeft / numRight;
 

--- a/tests/custom.yaml
+++ b/tests/custom.yaml
@@ -121,3 +121,16 @@ tests:
             units: ""
             name: "other ingredient"
       metadata: []
+
+
+  testNonnumericQuantityContainingSlash:
+    source: |
+      @soy sauce{1/4 cup}
+    result:
+      steps:
+        -
+          - type: ingredient
+            quantity: "1/4 cup"
+            units: ""
+            name: "soy sauce"
+      metadata: []


### PR DESCRIPTION
Currently parsing the string `@soy sauce{1/4 cup}` returns an ingredient with quantity `1` and no unit. This PR corrects this behavior so that it instead parses the quantity as `1/4 cup`. 