### PR TITLE
add matchStart and matchEnd to matched syntax objs

### DIFF
--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -80,6 +80,8 @@ export default class Parser {
                     step.push({
                         type: 'text',
                         value: line.substring(pos, match.index),
+                        matchStart: pos,
+                        matchEnd: match.index || line.substring(pos, match.index).length
                     });
                 }
 
@@ -88,6 +90,9 @@ export default class Parser {
                     metadata[groups.key.trim()] = groups.value.trim();
                 }
 
+                const matchStart = match.index;
+                const matchEnd = match.index ? match.index + match[0].length - 1 : undefined;
+
                 // single word ingredient
                 if (groups.sIngredientName) {
                     const ingredient: Ingredient = {
@@ -95,6 +100,8 @@ export default class Parser {
                         name: groups.sIngredientName,
                         quantity: this.defaultIngredientAmount,
                         units: this.defaultUnits,
+                        matchStart,
+                        matchEnd
                     };
 
                     ingredients.push(ingredient);
@@ -110,6 +117,8 @@ export default class Parser {
                             parseQuantity(groups.mIngredientQuantity) ??
                             this.defaultIngredientAmount,
                         units: parseUnits(groups.mIngredientUnits) ?? this.defaultUnits,
+                        matchStart,
+                        matchEnd
                     };
 
                     ingredients.push(ingredient);
@@ -122,6 +131,8 @@ export default class Parser {
                         type: 'cookware',
                         name: groups.sCookwareName,
                         quantity: this.defaultCookwareAmount,
+                        matchStart,
+                        matchEnd
                     };
 
                     cookwares.push(cookware);
@@ -136,6 +147,8 @@ export default class Parser {
                         quantity:
                             parseQuantity(groups.mCookwareQuantity) ??
                             this.defaultCookwareAmount,
+                        matchStart, 
+                        matchEnd
                     };
 
                     cookwares.push(cookware);
@@ -149,6 +162,8 @@ export default class Parser {
                         name: groups.timerName,
                         quantity: parseQuantity(groups.timerQuantity) ?? 0,
                         units: parseUnits(groups.timerUnits) ?? this.defaultUnits,
+                        matchStart, 
+                        matchEnd
                     });
                 }
 
@@ -161,6 +176,8 @@ export default class Parser {
                 step.push({
                     type: 'text',
                     value: line.substring(pos),
+                    matchStart: pos, 
+                    matchEnd: pos + line.length - 1
                 });
             }
 

--- a/src/cooklang.ts
+++ b/src/cooklang.ts
@@ -1,9 +1,15 @@
+export interface MatchResult {
+    matchStart: number | undefined;
+    matchEnd: number | undefined;
+}
+
+
 /**
  * An ingredient
  *
  * @see {@link https://cooklang.org/docs/spec/#ingredients|Cooklang Ingredient}
  */
-export interface Ingredient {
+export interface Ingredient extends MatchResult {
     type: 'ingredient';
     name: string;
     quantity: string | number;
@@ -15,7 +21,7 @@ export interface Ingredient {
  *
  * @see {@link https://cooklang.org/docs/spec/#cookware|Cooklang Cookware}
  */
-export interface Cookware {
+export interface Cookware extends MatchResult {
     type: 'cookware';
     name: string;
     quantity: string | number;
@@ -26,7 +32,7 @@ export interface Cookware {
  *
  * @see {@link https://cooklang.org/docs/spec/#timer|Cooklang Timer}
  */
-export interface Timer {
+export interface Timer extends MatchResult {
     type: 'timer';
     name?: string;
     quantity: string | number;
@@ -36,7 +42,7 @@ export interface Timer {
 /**
  * A piece of text
  */
-export interface Text {
+export interface Text extends MatchResult {
     type: 'text';
     value: string;
 }


### PR DESCRIPTION
What do you think of having the position of the matched objects in the parsed result? This would help a lot in cases where you want to perform actions depending on your current caret position or on text selection.

Like for example I would like to open a autocompletion select with a list of ingredients when the caret is touching a part of text identified as an ingredient.

To achieve this I'm currently forced to re-apply the regex to the text and get the match start-end positions, but this is like parsing the text twice. Since this information is already available in `Parser` context I think it would be great to add it in