### PR TITLE
Fixed parsing behavior for single word ingredients/cookware followed by punctuation

### DIFF
--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1,15 +1,15 @@
 const metadata = /^>>\s*(?<key>.+?):\s*(?<value>.+)/;
 
-const multiwordIngredient = /@(?<mIngredientName>[^@#~[]+?){(?<mIngredientQuantity>[^]*?)(?:%(?<mIngredientUnits>[^}]+?))?}/;
-const singleWordIngredient = /@(?<sIngredientName>[^\s]+)/;
+const multiwordIngredient = /@(?<mIngredientName>[^@#~[]+?)\{(?<mIngredientQuantity>[^]*?)(?:%(?<mIngredientUnits>[^}]+?))?\}/;
+const singleWordIngredient = /@(?<sIngredientName>[^\s\t\p{Zs}\p{P}]+)/;
 
-const multiwordCookware = /#(?<mCookwareName>[^@#~[]+?){(?<mCookwareQuantity>.*?)}/;
-const singleWordCookware = /#(?<sCookwareName>[^\s]+)/;
+const multiwordCookware = /#(?<mCookwareName>[^@#~[]+?)\{(?<mCookwareQuantity>.*?)\}/;
+const singleWordCookware = /#(?<sCookwareName>[^\s\t\p{Zs}\p{P}]+)/;
 
-const timer = /~(?<timerName>.*?)(?:{(?<timerQuantity>.*?)(?:%(?<timerUnits>.+?))?})/;
+const timer = /~(?<timerName>.*?)(?:\{(?<timerQuantity>.*?)(?:%(?<timerUnits>.+?))?\})/;
 
 export const comment = /--.*/g;
 export const blockComment = /\s*\[\-.*?\-\]\s*/g;
 
 export const shoppingList = /\[(?<name>.+)\]\n(?<items>[^]*?)(?:\n\n|$)/g;
-export const tokens = new RegExp([metadata, multiwordIngredient, singleWordIngredient, multiwordCookware, singleWordCookware, timer].map(r => r.source).join('|'), 'g');
+export const tokens = new RegExp([metadata, multiwordIngredient, singleWordIngredient, multiwordCookware, singleWordCookware, timer].map(r => r.source).join('|'), 'gu');

--- a/tests/custom.yaml
+++ b/tests/custom.yaml
@@ -58,6 +58,19 @@ tests:
             name: "ingredient with spaces"
       metadata: []
 
+  testSingleWordIngredientFollowedByPunctuation:
+    source: |
+      @ingredient, then step.
+    result:
+      steps:
+        -
+          - type: ingredient
+            quantity: "some"
+            units: ""
+            name: "ingredient"
+          - type: text
+            value: ", then step."
+      metadata: []
 
   testMultiWordFollowingSingleWordCookware:
     source: |
@@ -73,6 +86,19 @@ tests:
           - type: cookware
             name: "big cooking pot"
             quantity: 1
+      metadata: []
+
+  testSingleWordCookwareFollowedByPunctuation:
+    source: |
+      #pan, then step.
+    result:
+      steps:
+        -
+          - type: cookware
+            name: "pan"
+            quantity: 1
+          - type: text
+            value: ", then step."
       metadata: []
 
 


### PR DESCRIPTION
Presently punctuation is included into single word ingredients/cookware such as `Add @milk. Stir.` 

I brought the tokens in line with the EBNF to exclude unicode categories `Zs` and `P`, and tabulation character. I believe `\s` can be removed from the regex but I didn't want to create side-effects I wasn't aware of.

I included a test for cookware and ingredients with punctuation.