### PR TITLE
Add support for multiline block comments

### DIFF
--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -9,7 +9,7 @@ const singleWordCookware = /#(?<sCookwareName>[^\s\t\p{Zs}\p{P}]+)/;
 const timer = /~(?<timerName>.*?)(?:\{(?<timerQuantity>.*?)(?:%(?<timerUnits>.+?))?\})/;
 
 export const comment = /--.*/g;
-export const blockComment = /\s*\[\-.*?\-\]\s*/g;
+export const blockComment = /\s*\[\-[\s\S]*?\-\]\s*/g;
 
 export const shoppingList = /\n\s*\[(?<name>.+)\]\n(?<items>[^]*?)(?:\n\n|$)/g;
 export const tokens = new RegExp([metadata, multiwordIngredient, singleWordIngredient, multiwordCookware, singleWordCookware, timer].map(r => r.source).join('|'), 'gu');

--- a/tests/custom.yaml
+++ b/tests/custom.yaml
@@ -40,6 +40,26 @@ tests:
             name: "pepper"
       metadata: []
 
+  testMultilineBlockComments:
+    source: |
+      Add the @bacon [- make sure 
+      not to burn -] and cook for ~{2%minutes}
+    result:
+      steps:
+        - - type: text
+            value: "Add the "
+          - type: ingredient
+            quantity: "some"
+            units: ""
+            name: "bacon"
+          - type: text
+            value: " and cook for "
+          - type: timer
+            quantity: 2
+            units: "minutes"
+            name: ""
+      metadata: [] 
+
   testMultiWordFollowingSingleWordIngredient:
     source: |
       @ingredient and @ingredient with spaces{}


### PR DESCRIPTION
A comment like 
```
Add the @bacon [- make sure 
      not to burn -] and cook for ~{2%minutes}
```
Will create strange steps with parts of the comment instead of removing it all. I changed the regexp a little so this doesn't happen.