### PR TITLE
Add support for Short-hand ingredient preparations

### DIFF
--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -122,6 +122,7 @@ export default class Parser {
                             parseQuantity(groups.mIngredientQuantity) ??
                             this.defaultIngredientAmount,
                         units: parseUnits(groups.mIngredientUnits) ?? this.defaultUnits,
+                        ...(groups.mIngredientPreparation ? { preparation: groups.mIngredientPreparation } : null),
                     };
 
                     if (this.includeStepNumber) ingredient.step = stepNumber;

--- a/src/Recipe.ts
+++ b/src/Recipe.ts
@@ -55,6 +55,7 @@ export default class Recipe {
                     stepStr += '{';
                     if (item.quantity) stepStr += item.quantity;
                     if ('units' in item && item.units) stepStr += '%' + item.units;
+                    if ('preparation' in item && item.preparation) stepStr += `(${item.preparation})`
                     stepStr += '}';
                 }
             }

--- a/src/cooklang.ts
+++ b/src/cooklang.ts
@@ -8,6 +8,7 @@ export interface Ingredient {
     name: string;
     quantity: string | number;
     units: string;
+    preparation?: string;
     step?: number;
 }
 

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1,6 +1,6 @@
 const metadata = /^>>\s*(?<key>.+?):\s*(?<value>.+)/;
 
-const multiwordIngredient = /@(?<mIngredientName>[^@#~[]+?)\{(?<mIngredientQuantity>[^]*?)(?:%(?<mIngredientUnits>[^}]+?))?\}/;
+const multiwordIngredient = /@(?<mIngredientName>[^@#~[]+?)\{(?<mIngredientQuantity>[^]*?)(?:%(?<mIngredientUnits>[^}]+?))?\}(\((?<mIngredientPreparation>[^]*?)\))?/;
 const singleWordIngredient = /@(?<sIngredientName>[^\s\t\p{Zs}\p{P}]+)/;
 
 const multiwordCookware = /#(?<mCookwareName>[^@#~[]+?)\{(?<mCookwareQuantity>.*?)\}/;

--- a/tests/custom.yaml
+++ b/tests/custom.yaml
@@ -198,3 +198,16 @@ tests:
             value: "step"
       metadata:
         "source": "example.com"
+        
+  testShortHandPreparation:
+    source: |
+      @onion{1}(peeled and finely chopped)
+    result:
+      steps: 
+        -
+          - type: ingredient
+            quantity: 1
+            units: ""
+            name: "onion"
+            preparation: "peeled and finely chopped"
+      metadata: []


### PR DESCRIPTION
This is described in the specification under the advanced section. https://cooklang.org/docs/spec/#short-hand-preparations

For what it's worth, the official Cooklang playground does not properly support Short-hand ingredient preparations either.

Includes an automated test based on what is described in the specification.