### PR TITLE
enable publishing preview versions

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+      - run: npm ci
       - run: npm run build
       - name: Publish Preview Versions
         run: npx pkg-pr-new publish

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,18 @@
+name: preview
+
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm run build
+      - name: Publish Preview Versions
+        run: npx pkg-pr-new publish


### PR DESCRIPTION
## Motivation

Using `pkg.pr.new`, we can publish preview versions for each commit. This enables easier testing downstream. Folks can open a PR and immediately try out the package from the npm compatible registry.
